### PR TITLE
Make README give working examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ by adding `meilisearch` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:meilisearch, "~> 0.25.2"}
+    {:meilisearch, "~> 0.25.0", git: "https://github.com/nutshell-lab/meilisearch-elixir"}
   ]
 end
 ```
@@ -21,10 +21,10 @@ end
 
 ```elixir
 # Create Index
-Meilisearch.Index.create("index_name")
+Meilisearch.Indexes.create("index_name")
 
 # Create Index and set primary key
-Meilisearch.Index.create("index_name", primary_key: "key_name")
+Meilisearch.Indexes.create("index_name", primary_key: "key_name")
 
 # Insert documents
 documents = [


### PR DESCRIPTION
Currently the examples in README do not reflect how to use this fork of the package. This should fix it.

Currently the version in mix.exs file is "0.25.0", so having anything higher in the `deps` will not work.
Also the `Meilisearch.Index` was renamed to `Meilisearch.Indexes` so the README should reflect this as well.